### PR TITLE
chore: update extension key

### DIFF
--- a/Classes/Enumeration/Configuration.php
+++ b/Classes/Enumeration/Configuration.php
@@ -6,5 +6,5 @@ namespace MoveElevator\Typo3Toolbox\Enumeration;
 
 enum Configuration: string
 {
-    case EXT_KEY = 'typo3-toolbox';
+    case EXT_KEY = 'typo3_toolbox';
 }

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -9,6 +9,6 @@ return [
         'backend.form',
     ],
     'imports' => [
-        '@move-elevator/typo3-toolbox/' => 'EXT:typo3-toolbox/Resources/Public/JavaScript/Backend/',
+        '@move-elevator/typo3-toolbox/' => 'EXT:typo3_toolbox/Resources/Public/JavaScript/Backend/',
     ],
 ];

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For example:
     identifier="sentryMonitoringService"
     nonce="{f:security.nonce()}"
     priority="1"
-    src="EXT:typo3-toolbox/Resources/Public/JavaScript/Service/SentryMonitoringService.min.js"
+    src="EXT:typo3_toolbox/Resources/Public/JavaScript/Service/SentryMonitoringService.min.js"
 />
 ```
 
@@ -61,13 +61,13 @@ Sentry monitoring is enabled by default for frontend and backend issue/ performa
 Disable backend issue tracking:
 
 ```
-$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['typo3-toolbox']['sentryBackendEnabled'] = 0;
+$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['typo3_toolbox']['sentryBackendEnabled'] = 0;
 ```
 
 Disable frontend issue/ performance tracking:
 
 ```
-$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['typo3-toolbox']['sentryFrontendEnabled'] = 0;
+$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['typo3_toolbox']['sentryFrontendEnabled'] = 0;
 ```
 
 ## Documentation

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <xliff version="1.0">
-	<file source-language="en" datatype="plaintext" original="messages" product-name="typo3-toolbox">
+	<file source-language="en" datatype="plaintext" original="messages" product-name="typo3_toolbox">
 		<header/>
 		<body>
 			<trans-unit id="extension_manager.sentry_backend_enabled">

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
 	},
 	"extra": {
 		"typo3/cms": {
-			"extension-key": "typo3-toolbox"
+			"extension-key": "typo3_toolbox"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all references of the extension key from "typo3-toolbox" to "typo3_toolbox" across the application, including configuration files, documentation, localization, and asset paths, to ensure consistent naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->