### PR TITLE
fix: replace deprecated useNonce asset option with csp

### DIFF
--- a/Classes/ViewHelpers/Asset/CssViewHelper.php
+++ b/Classes/ViewHelpers/Asset/CssViewHelper.php
@@ -53,7 +53,8 @@ final class CssViewHelper extends AbstractTagBasedViewHelper
     {
         parent::initializeArguments();
         $this->registerArgument('disabled', 'bool', 'Define whether or not the described stylesheet should be loaded and applied to the document.');
-        $this->registerArgument('useNonce', 'bool', 'Whether to use the global nonce value', false, false);
+        $this->registerArgument('useNonce', 'bool', 'Whether to use the global nonce value. @deprecated use "csp" instead, will be removed in 3.0.0.', false, null);
+        $this->registerArgument('csp', 'bool', 'Whether to collect a CSP hash value for this asset', false, null);
         $this->registerArgument('identifier', 'string', 'Use this identifier within templates to only inject your CSS once, even though it is added multiple times.', true);
         $this->registerArgument('priority', 'boolean', 'Define whether the CSS should be included before other CSS. CSS will always be output in the <head> tag.', false, false);
         $this->registerArgument('inline', 'bool', 'Define whether or not the referenced file should be loaded as inline styles (Only to be used if \'href\' is set).', false, false);
@@ -73,9 +74,15 @@ final class CssViewHelper extends AbstractTagBasedViewHelper
 
         $file = $attributes['href'] ?? null;
         unset($attributes['href']);
+
+        $useCsp = $this->arguments['csp'];
+        if ($this->arguments['useNonce'] !== null) {
+            $useCsp = (bool)$this->arguments['useNonce'];
+        }
+
         $options = [
             'priority' => $this->arguments['priority'],
-            'useNonce' => $this->arguments['useNonce'],
+            'csp' => $useCsp,
             'noscript' => (bool)($this->arguments['noscript'] ?? false),
         ];
 


### PR DESCRIPTION
## Summary

- Replace the deprecated \`useNonce\` asset option with \`csp\` in the CSS asset ViewHelper, removing the TYPO3 v14 deprecation warning *\"The option key \"useNonce\" for assets is deprecated, use \"csp\" instead.\"* (raised by \`AssetRenderer\`), which is slated for removal in v15.
- Add a dedicated \`csp\` ViewHelper argument matching the TYPO3 core CSS asset ViewHelper.
- Keep \`useNonce\` as a deprecated, backward-compatible argument that maps onto \`csp\` (since it was already shipped in 2.0.0), to be removed in 3.0.0.

## Changes

- \`Classes/ViewHelpers/Asset/CssViewHelper.php\`
  - New \`csp\` argument (bool, default \`null\`).
  - \`useNonce\` argument kept but marked \`@deprecated\` (default changed to \`null\` to detect explicit use); maps to \`csp\` only when explicitly set.
  - Asset \`$options\` now pass \`csp\` instead of the deprecated \`useNonce\` key to \`addStyleSheet()\`/\`addInlineStyleSheet()\`.

## Notes

- CSP/nonce behaviour is unchanged; existing \`useNonce=\"…\"\` calls keep working.
- composer constraints and ext_emconf untouched.
- No analogous ScriptViewHelper exists yet — same mapping should be applied if one is added later.